### PR TITLE
Refactor

### DIFF
--- a/WSL/.zprofile
+++ b/WSL/.zprofile
@@ -1,0 +1,15 @@
+# Path
+# ref: https://qiita.com/magicant/items/d3bb7ea1192e63fba850
+## pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+## Poetry
+export PATH="/home/neko/.local/bin:$PATH"
+## CUDA
+export PATH=/usr/local/cuda:/usr/local/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+## TensorFlow
+### デフォルトだとlogが全て出てくる
+### ref: https://70vps.net/wsl-19.html
+export TF_CPP_MIN_LOG_LEVEL=1

--- a/WSL/.zshrc
+++ b/WSL/.zshrc
@@ -109,18 +109,3 @@ function _custom_tree() {
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-
-# Path
-## pyenv
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
-## Poetry
-export PATH="/home/neko/.local/bin:$PATH"
-## CUDA
-export PATH=/usr/local/cuda:/usr/local/cuda/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
-## TensorFlow
-### デフォルトだとlogが全て出てくる
-### ref: https://70vps.net/wsl-19.html
-export TF_CPP_MIN_LOG_LEVEL=1

--- a/Windows/Keyboard/AutoHotKey/win2mac.ahk
+++ b/Windows/Keyboard/AutoHotKey/win2mac.ahk
@@ -1,11 +1,38 @@
 #Requires AutoHotkey v2.0
 #SingleInstance Force
 
+;-----------------------------------------------------------
+; ref: https://qiita.com/kenichiro_ayaki/items/d55005df2787da725c6f
+; IMEの状態の取得
+;   WinTitle="A"    対象Window
+;   戻り値          1:ON / 0:OFF
+;-----------------------------------------------------------
+IME_GET(WinTitle:="A")  {
+    hwnd := WinExist(WinTitle)
+    if  (WinActive(WinTitle))   {
+        ptrSize := !A_PtrSize ? 4 : A_PtrSize
+        cbSize := 4+4+(PtrSize*6)+16
+        stGTI := Buffer(cbSize,0)
+        NumPut("DWORD", cbSize, stGTI.Ptr,0)   ;   DWORD   cbSize;
+        hwnd := DllCall("GetGUIThreadInfo", "Uint",0, "Uint", stGTI.Ptr)
+                 ? NumGet(stGTI.Ptr,8+PtrSize,"Uint") : hwnd
+    }
+    return DllCall("SendMessage"
+          , "UInt", DllCall("imm32\ImmGetDefaultIMEWnd", "Uint",hwnd)
+          , "UInt", 0x0283  ;Message : WM_IME_CONTROL
+          ,  "Int", 0x0005  ;wParam  : IMC_GETOPENSTATUS
+          ,  "Int", 0)      ;lParam  : 0
+}
+
+
 ; Macの様な矢印入力を可能にする
+; ref: https://www.autohotkey.com/docs/v2/lib/_HotIf.htm
+#HOTIF (IME_GET() = 1)
 :*:zh::←
 :*:zj::↓
 :*:zk::↑
 :*:zl::→
+#HOTIF
 
 ;文字の削除
 F13 & H::Send "{Blind}{Backspace}"


### PR DESCRIPTION
# 1. Zsh
Exporting environmental variables is preferred in `.zprofile`.

# 2. Windows
The previous code in `win2mac.ahk` replaces zl with → (or zk with ↑ etc) even if IME is turned off.